### PR TITLE
FIX: Prevent error in neos 4

### DIFF
--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <title><f:render section="Title" /></title>
-        <f:base />
+
     </head>
     <body>
         <f:flashMessages class="flashmessages" />


### PR DESCRIPTION
The <f:base /> is removed in neos 4