### PR TITLE
Set correct group for property

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -18,5 +18,8 @@
     group: 'form.finisher'
   properties:
     'identifier':
+      ui:
+        inspector:
+          group: 'finisher'
       validation:
         'Neos.Neos/Validation/NotEmptyValidator': {  }


### PR DESCRIPTION
The group for the 'identifier' property defined in the `Neos.Form.Builder:IdentifierMixin` is `formElement`. This group is not available in `Neos.Form.Builder:AbstractFinisher`. `Neos.Form.Builder:AbstractFinisher` has group `finisher` and therefore I set this as the group for the property `identifier`