### PR TITLE
[FEATURE] fallback to field label on missing id, export all saved field ids over time

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -30,3 +30,5 @@ Wegmeister:
     title: 'Database Export'
     subject: 'Database Export'
     datetimeFormat: 'Y-m-d H:i:s'
+    ignoredExportNodeTypes:
+      - 'Neos.Form.Builder:Section'

--- a/Resources/Private/Templates/DatabaseStorage/Show.html
+++ b/Resources/Private/Templates/DatabaseStorage/Show.html
@@ -1,7 +1,14 @@
 {namespace neos=Neos\Neos\ViewHelpers}
 <f:layout name="Default" />
 
-<f:section name="Title">{neos:backend.translate(id: 'storage.databaseStorage')} - {neos:backend.translate(id: 'storage.entriesForX', arguments: {0: identifier})}</f:section>
+<f:section name="Title">
+  <p><f:link.action action="index" class="neos-button">{neos:backend.translate(id: 'storage.backToIdentifiers')}</f:link.action></p>
+<div class="neos-row-fluid">
+  <legend>
+    {neos:backend.translate(id: 'storage.databaseStorage')} - [{f:if(condition: '{entries -> f:count()} > 0', then: '{entries -> f:count()}')}] {neos:backend.translate(id: 'storage.entriesForX', arguments: {0: identifier})}
+  </legend>
+</div>
+</f:section>
 
 <f:section name="Content">
   <style>


### PR DESCRIPTION
    if no field ID is set the NodeIdentifier (like 7bf85ad4-5be8-48d1-a9e6-894384e0d4f3) was used as column header.
    This change enhances the readability of the export files by using the field label if set.

    Exporting form data only extracted the columns of the last entry. If the form has changed over time by
    adding or removing fields those where not exportet. The pacht now looks up all saved entry attributes and
    includes them to the export data.

    [FEATURE] add setting ignoredExportNodeTypes
    [FEATURE] An additional "back to list of IDs" button has been added on top of the list.
    [BUGFIX] handle array field values (i.e. multiple select, checkboxes)
