### PR TITLE
BUGFIX: Prevent dimensions array to be null

### DIFF
--- a/Classes/Service/DatabaseStorageService.php
+++ b/Classes/Service/DatabaseStorageService.php
@@ -198,7 +198,7 @@ class DatabaseStorageService
      * @throws \Neos\ContentRepository\Exception\NodeException
      * @throws \Neos\Eel\Exception
      */
-    protected function getFormElementsNodeData(?array $dimensions = null): ?array
+    protected function getFormElementsNodeData(?array $dimensions = []): ?array
     {
         if (!empty($this->formElementsNodeData)) {
             // First-level cache


### PR DESCRIPTION
If a Neos instance does not have any content dimensions configured, the dimensions variable in the getFormElementsNodeData function remains unchanged. As a result, the initial value for this variable, which is null, is used.

This causes an issue during further processing because the code expects an array but instead encounters a null value, leading to an exception.

This commit ensures that the dimensions variable is properly initialized to an empty array when no content dimensions are configured, preventing the exception from occurring.

Fixes: #36