### PR TITLE
FEATURE: Adds cleanup commands for the database storage

### DIFF
--- a/Classes/Command/DatabaseStorageCommandController.php
+++ b/Classes/Command/DatabaseStorageCommandController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Wegmeister\DatabaseStorage\Command;
+
+use DateTime;
+use Wegmeister\DatabaseStorage\Service\DatabaseStorageService;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Cli\CommandController;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class DatabaseStorageCommandController extends CommandController
+{
+    /**
+     * @var DatabaseStorageService
+     * @Flow\Inject
+     */
+    protected $databaseStorageService;
+
+    // TODO: set configurations and define path
+    /**
+     * @Flow\InjectConfiguration(package="Vendor.Package", path="databaseStorageCleanup.storageCleanupConfiguration")
+     * @var array
+     */
+    protected $storageCleanupConfiguration;
+
+    /**
+     * Deletes entries of honorary members, older than 6 months
+     */
+    public function cleanUpConfiguredStoragesCommand(): void
+    {
+        foreach ($this->storageCleanupConfiguration as $storageIdentifier => $daysToKeepEntriesBeforeCleanup) {
+            $this->outputLine('Removing entries from storage "%s" older than %s days...', [$storageIdentifier, $daysToKeepEntriesBeforeCleanup]);
+            $outdatedEntries = 0;
+            foreach ($this->databaseStorageService->getEntriesForCleanup($storageIdentifier) as $entry) {
+                if (date_diff($entry->getDateTime(), new DateTime('now'))->days >= $daysToKeepEntriesBeforeCleanup) {
+                    $this->databaseStorageService->deleteEntry($entry);
+                    $outdatedEntries++;
+                }
+            }
+            $this->outputLine('Removed %s entries from storage "%s".', [$outdatedEntries, $storageIdentifier]);
+        }
+    }
+}

--- a/Classes/Command/DatabaseStorageCommandController.php
+++ b/Classes/Command/DatabaseStorageCommandController.php
@@ -32,13 +32,14 @@ class DatabaseStorageCommandController extends CommandController
     public function cleanUpConfiguredStoragesCommand(): void
     {
         foreach ($this->storageCleanupConfiguration as $storageIdentifier => $dateInterval) {
-            $newDateInterval = new DateInterval($dateInterval);
+            $newDateInterval = new DateInterval($dateInterval['dateInterval']);
             $intervalDateTime = (new DateTime())->add($newDateInterval);
+            $daysToKeepData = date_diff($intervalDateTime, new DateTime('now'))->days;
 
-            $this->outputLine('Removing entries from storage "%s" older than %s days...', [$storageIdentifier, $newDateInterval->format('d')]);
+            $this->outputLine('Removing entries from storage "%s" older than %s days...', [$storageIdentifier, $daysToKeepData]);
             $outdatedEntries = 0;
             foreach ($this->databaseStorageService->getEntriesForCleanup($storageIdentifier) as $entry) {
-                if (date_diff($entry->getDateTime(), new DateTime('now')) >= $intervalDateTime) {
+                if (date_diff($entry->getDateTime(), new DateTime('now'))->days >= $daysToKeepData) {
                     $this->databaseStorageService->deleteEntry($entry);
                     $outdatedEntries++;
                 }

--- a/Classes/Command/DatabaseStorageCommandController.php
+++ b/Classes/Command/DatabaseStorageCommandController.php
@@ -21,7 +21,7 @@ class DatabaseStorageCommandController extends CommandController
 
     // TODO: set configurations and define path
     /**
-     * @Flow\InjectConfiguration(package="Vendor.Package", path="databaseStorageCleanup.storageCleanupConfiguration")
+     * @Flow\InjectConfiguration(package="Wegmeister.DatabaseStorage", path="cleanup")
      * @var array
      */
     protected $storageCleanupConfiguration;

--- a/Classes/Command/DatabaseStorageCommandController.php
+++ b/Classes/Command/DatabaseStorageCommandController.php
@@ -30,11 +30,11 @@ class DatabaseStorageCommandController extends CommandController
      */
     public function cleanUpConfiguredStoragesCommand(): void
     {
-        foreach ($this->storageCleanupConfiguration as $storageIdentifier => $daysToKeepEntriesBeforeCleanup) {
-            $this->outputLine('Removing entries from storage "%s" older than %s days...', [$storageIdentifier, $daysToKeepEntriesBeforeCleanup]);
+        foreach ($this->storageCleanupConfiguration as $storageIdentifier => $daysToKeep) {
+            $this->outputLine('Removing entries from storage "%s" older than %s days...', [$storageIdentifier, $daysToKeep]);
             $outdatedEntries = 0;
             foreach ($this->databaseStorageService->getEntriesForCleanup($storageIdentifier) as $entry) {
-                if (date_diff($entry->getDateTime(), new DateTime('now'))->days >= $daysToKeepEntriesBeforeCleanup) {
+                if (date_diff($entry->getDateTime(), new DateTime('now'))->days >= $daysToKeep) {
                     $this->databaseStorageService->deleteEntry($entry);
                     $outdatedEntries++;
                 }

--- a/Classes/Command/DatabaseStorageCommandController.php
+++ b/Classes/Command/DatabaseStorageCommandController.php
@@ -17,34 +17,83 @@ class DatabaseStorageCommandController extends CommandController
      * @var DatabaseStorageService
      * @Flow\Inject
      */
-    protected $databaseStorageService;
+    protected DatabaseStorageService $databaseStorageService;
 
-    // TODO: set configurations and define path
     /**
      * @Flow\InjectConfiguration(package="Wegmeister.DatabaseStorage", path="cleanup")
      * @var array
      */
-    protected $storageCleanupConfiguration;
+    protected array $storageCleanupConfiguration;
 
     /**
      * Deletes entries of configured storages older than configured date interval
      */
     public function cleanUpConfiguredStoragesCommand(): void
     {
-        foreach ($this->storageCleanupConfiguration as $storageIdentifier => $dateInterval) {
-            $newDateInterval = new DateInterval($dateInterval['dateInterval']);
-            $intervalDateTime = (new DateTime())->add($newDateInterval);
-            $daysToKeepData = date_diff($intervalDateTime, new DateTime('now'))->days;
+        $this->outputFormatted('<b>Cleanup of configured storages</b>');
+        $this->outputLine('');
 
-            $this->outputLine('Removing entries from storage "%s" older than %s days...', [$storageIdentifier, $daysToKeepData]);
-            $outdatedEntries = 0;
-            foreach ($this->databaseStorageService->getEntriesForCleanup($storageIdentifier) as $entry) {
-                if (date_diff($entry->getDateTime(), new DateTime('now'))->days >= $daysToKeepData) {
-                    $this->databaseStorageService->deleteEntry($entry);
-                    $outdatedEntries++;
-                }
-            }
-            $this->outputLine('Removed %s entries from storage "%s".', [$outdatedEntries, $storageIdentifier]);
+        if (empty($this->storageCleanupConfiguration)) {
+            $this->outputFormatted('No cleanup configuration found.', [], 4);
+            $this->outputFormatted('Please configure the cleanup for Wegmeister.DatabaseStorage in Settings.yaml.', [], 4);
+            return;
         }
+
+        $results = [];
+        foreach ($this->storageCleanupConfiguration as $storageIdentifier => $storageCleanupConfiguration) {
+            $results[$storageIdentifier] = ['storageIdentifier' => $storageIdentifier, 'messages' => ''];
+
+            // Check if the date interval is valid
+            try {
+                $newDateInterval = $this->getDateIntervalFromConfiguration($storageIdentifier);
+            } catch (\Exception $exception) {
+                $results[$storageIdentifier]['messages'] .= $exception->getMessage() . PHP_EOL;
+                continue;
+            }
+
+            // Check if we have entries for the storage identifier
+            $daysToKeepData = $this->getDaysToKeepFromConfiguredInterval($newDateInterval);
+            $amountOfEntries = $this->databaseStorageService->getAmountOfEntriesByStorageIdentifier($storageIdentifier);
+            if ($amountOfEntries === 0) {
+                $results[$storageIdentifier]['messages'] .= sprintf('No entries found in storage "%s".', $storageIdentifier) . PHP_EOL;
+                continue;
+            }
+
+            // Cleanup the storage
+            $results[$storageIdentifier]['messages'] .= vsprintf('Removing entries from storage "%s" older than %s days...', [$storageIdentifier, $daysToKeepData]) . PHP_EOL;
+            $amountOfOutdatedEntries = $this->databaseStorageService->cleanupByStorageIdentifierAndDateInterval($storageIdentifier, $newDateInterval);
+            $results[$storageIdentifier]['messages'] .= vsprintf('Removed %s entries from storage "%s" (%s entries in total).', [$amountOfOutdatedEntries, $storageIdentifier, $amountOfEntries]);
+        }
+
+        $this->output->outputTable($results, ['storageIdentifier', 'messages'], 'Cleanup results');
+    }
+
+    protected function getDateIntervalFromConfiguration(string $storageIdentifier): DateInterval
+    {
+        $storageCleanupConfiguration = $this->storageCleanupConfiguration[$storageIdentifier] ?? null;
+
+        if (!isset($storageCleanupConfiguration['dateInterval'])) {
+            $errorMessage = vsprintf(
+                'No date interval configuration for storage "%s" has been found.',
+                [$storageIdentifier]
+            );
+            throw new \InvalidArgumentException($errorMessage, 1732462801);
+        }
+
+        try {
+            return new DateInterval($storageCleanupConfiguration['dateInterval']);
+        } catch (\Exception $exception) {
+            $errorMessage = vsprintf(
+                'Invalid date interval configuration for storage "%s".',
+                [$storageIdentifier]
+            );
+            throw new \InvalidArgumentException($errorMessage, 1732462753);
+        }
+    }
+
+    protected function getDaysToKeepFromConfiguredInterval(DateInterval $dateInterval): int
+    {
+        $intervalDateTime = (new DateTime())->add($dateInterval);
+        return date_diff($intervalDateTime, new DateTime('now'))->days;
     }
 }

--- a/Classes/Command/DatabaseStorageCommandController.php
+++ b/Classes/Command/DatabaseStorageCommandController.php
@@ -21,9 +21,9 @@ class DatabaseStorageCommandController extends CommandController
 
     /**
      * @Flow\InjectConfiguration(package="Wegmeister.DatabaseStorage", path="cleanup")
-     * @var array
+     * @var array|null
      */
-    protected array $storageCleanupConfiguration;
+    protected ?array $storageCleanupConfiguration;
 
     /**
      * Deletes entries of configured storages older than configured date interval

--- a/Classes/Domain/Repository/DatabaseStorageRepository.php
+++ b/Classes/Domain/Repository/DatabaseStorageRepository.php
@@ -72,12 +72,7 @@ class DatabaseStorageRepository extends Repository
     public function findStorageidentifiers()
     {
         if ($this->identifiers === []) {
-            foreach ($this->findAll() as $item) {
-                if ($this->currentIdentifier !== $item->getStorageidentifier()) {
-                    $this->identifiers[] = $item->getStorageidentifier();
-                    $this->currentIdentifier = $item->getStorageidentifier();
-                }
-            }
+            $this->identifiers = $this->getStorageIdentifiers();
         }
 
         return $this->identifiers;
@@ -138,5 +133,25 @@ class DatabaseStorageRepository extends Repository
 
         $result = $queryBuilder->getQuery()->getResult();
         return array_column($result, 'storageidentifier');
+    }
+
+    /**
+     * Checks if there are entries for given storage identifier.
+     *
+     * @param string $storageIdentifier
+     * @return int
+     */
+    public function getAmountOfEntriesByStorageIdentifier(string $storageIdentifier): int
+    {
+        $query = $this->databaseStorageRepository->createQuery();
+        $constraints = [];
+        $constraints[] = $query->equals('storageidentifier', $storageIdentifier);
+        $query->matching(
+            $query->logicalAnd(
+                $constraints
+            )
+        );
+
+        return $query->count();
     }
 }

--- a/Classes/Domain/Repository/DatabaseStorageRepository.php
+++ b/Classes/Domain/Repository/DatabaseStorageRepository.php
@@ -15,6 +15,7 @@
 
 namespace Wegmeister\DatabaseStorage\Domain\Repository;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Neos\ContentRepository\Domain\Model\NodeData;
@@ -124,13 +125,16 @@ class DatabaseStorageRepository extends Repository
      */
     public function getStorageIdentifiers(array $excludedIdentifiers = []): array
     {
+        if (empty($excludedIdentifiers)) {
+            // If no excluded identifiers are given, we need to add an empty string to the array
+            $excludedIdentifiers[] = '';
+        }
         $queryBuilder = $this->entityManager->createQueryBuilder();
-        $excludedIdentifiersList = empty($excludedIdentifiers) ? '' : implode(',', $excludedIdentifiers);
         $queryBuilder->select('n.storageidentifier')
             ->from(DatabaseStorage::class, 'n')
             ->distinct(true)
             ->where('n.storageidentifier NOT IN(:excluded)')
-            ->setParameter('excluded', $excludedIdentifiersList);
+            ->setParameter('excluded', $excludedIdentifiers, Connection::PARAM_STR_ARRAY);
 
         $result = $queryBuilder->getQuery()->getResult();
         return array_column($result, 'storageidentifier');

--- a/Classes/Service/DatabaseStorageService.php
+++ b/Classes/Service/DatabaseStorageService.php
@@ -22,12 +22,18 @@ use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Neos\Domain\Service\SiteService;
 use Wegmeister\DatabaseStorage\Domain\Model\DatabaseStorage;
+use Wegmeister\DatabaseStorage\Domain\Repository\DatabaseStorageRepository;
 
 /**
  * @Flow\Scope("singleton")
  */
 class DatabaseStorageService
 {
+    /**
+     * @var DatabaseStorageRepository
+     * @Flow\Inject
+     */
+    protected $databaseStorageRepository;
 
     /**
      * @var array
@@ -444,5 +450,40 @@ class DatabaseStorageService
         }
 
         return '';
+    }
+
+    /**
+     * Deletes given entry.
+     *
+     * @param DatabaseStorage $entry
+     *
+     * @return void
+     */
+    public function deleteEntry($entry): void
+    {
+        $this->databaseStorageRepository->remove($entry);
+    }
+
+    /**
+     * Gets entries for given storage identifier.
+     *
+     * @param string $storageIdentifier
+     *
+     * @return \Generator
+     */
+    public function getEntriesForCleanup(string $storageIdentifier): \Generator
+    {
+        $query = $this->databaseStorageRepository->createQuery();
+        $constraints = [];
+        $constraints[] = $query->equals('storageidentifier', $storageIdentifier);
+        $query->matching(
+            $query->logicalAnd(
+                $constraints
+            )
+        );
+
+        foreach ($query->execute() as $entry) {
+            yield $entry;
+        }
     }
 }

--- a/Classes/Service/DatabaseStorageService.php
+++ b/Classes/Service/DatabaseStorageService.php
@@ -489,4 +489,15 @@ class DatabaseStorageService
             return 0;
         }
     }
+
+    /**
+     * Get a list of all storage identifiers.
+     *
+     * @param array $excludedStorageIdentifiers
+     * @return array
+     */
+    public function getListOfStorageIdentifiers(array $excludedStorageIdentifiers = []): array
+    {
+        return $this->databaseStorageRepository->getStorageIdentifiers($excludedStorageIdentifiers);
+    }
 }

--- a/Classes/Service/DatabaseStorageService.php
+++ b/Classes/Service/DatabaseStorageService.php
@@ -470,12 +470,13 @@ class DatabaseStorageService
      *
      * @param string $storageIdentifier Storage identifier
      * @param \DateInterval $dateInterval Date interval
+     * @param bool $removeFiles
      * @return int
      */
-    public function cleanupByStorageIdentifierAndDateInterval(string $storageIdentifier, \DateInterval $dateInterval): int
+    public function cleanupByStorageIdentifierAndDateInterval(string $storageIdentifier, \DateInterval $dateInterval, bool $removeFiles = false): int
     {
         try {
-            return $this->databaseStorageRepository->deleteByStorageIdentifierAndDateInterval($storageIdentifier, $dateInterval);
+            return $this->databaseStorageRepository->deleteByStorageIdentifierAndDateInterval($storageIdentifier, $dateInterval, $removeFiles);
         } catch (IllegalObjectTypeException|InvalidQueryException $e) {
             return 0;
         }

--- a/Classes/Service/DatabaseStorageService.php
+++ b/Classes/Service/DatabaseStorageService.php
@@ -462,16 +462,7 @@ class DatabaseStorageService
      */
     public function getAmountOfEntriesByStorageIdentifier(string $storageIdentifier): int
     {
-        $query = $this->databaseStorageRepository->createQuery();
-        $constraints = [];
-        $constraints[] = $query->equals('storageidentifier', $storageIdentifier);
-        $query->matching(
-            $query->logicalAnd(
-                $constraints
-            )
-        );
-
-        return $query->count();
+        return $this->databaseStorageRepository->getAmountOfEntriesByStorageIdentifier($storageIdentifier);
     }
 
     /**

--- a/Readme.md
+++ b/Readme.md
@@ -82,3 +82,24 @@ Wegmeister:
       - 'Neos.Form.Builder:Password'
       - 'Neos.Form.Builder:PasswordWithConfirmation'
 ```
+
+## Cleanup command
+
+The package comes with a cleanup command to delete data older than a date interval you can define in your settings.
+You can run the command manually or use a cron job.
+
+Add storages you wish to be cleaned up and define how long the data of each storage should be stored:
+
+```yaml
+
+Wegmeister:
+  DatabaseStorage:
+    cleanup:
+      # Add storage identifier you wish to be cleaned up
+      storageIdentifier1:
+        # Define how long the data should be stored as date interval
+        # https://www.php.net/manual/en/class.dateinterval.php
+        dateInterval: "P6M"
+      storageIdentifier2:
+          dateInterval: "P1Y"
+```

--- a/Readme.md
+++ b/Readme.md
@@ -83,9 +83,9 @@ Wegmeister:
       - 'Neos.Form.Builder:PasswordWithConfirmation'
 ```
 
-## Cleanup command
+## Cleanup commands
 
-The package comes with a cleanup command to delete data older than a date interval you can define in your settings.
+The package comes with cleanup commands to delete data older than a date interval you can define in your settings.
 You can run the command manually or use a cron job.
 
 Add storages you wish to be cleaned up and define how long the data of each storage should be stored:
@@ -103,3 +103,23 @@ Wegmeister:
       storageIdentifier2:
           dateInterval: "P1Y"
 ```
+
+Run the cleanup command for the configured storages:
+
+```
+./flow databasestorage:cleanupconfiguredstorages
+```
+
+You can also run a cleanup command for all existing storages. The command comes with parameters:
+
+| Parameter Name            | Data Type | Description                                                                                                                                     |
+|---------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| date-interval             | string    | Defines which data should be deleted. We use the PHP DateInterval format. You can find more information [here](https://www.php.net/manual/en/class.dateinterval.php). |
+| skip-configured-storages  | boolean   | If you have configured storages in your settings, you can skip them with this parameter.                                                       |
+
+
+
+```
+./flow databasestorage:cleanupallstorages --date-interval=P1M
+```
+

--- a/Readme.md
+++ b/Readme.md
@@ -100,8 +100,10 @@ Wegmeister:
         # Define how long the data should be stored as date interval
         # https://www.php.net/manual/en/class.dateinterval.php
         dateInterval: "P6M"
+        removeFiles: true
       storageIdentifier2:
           dateInterval: "P1Y"
+          removeFiles: false
 ```
 
 Run the cleanup command for the configured storages:
@@ -112,14 +114,15 @@ Run the cleanup command for the configured storages:
 
 You can also run a cleanup command for all existing storages. The command comes with parameters:
 
-| Parameter Name            | Data Type | Description                                                                                                                                     |
-|---------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| date-interval             | string    | Defines which data should be deleted. We use the PHP DateInterval format. You can find more information [here](https://www.php.net/manual/en/class.dateinterval.php). |
-| skip-configured-storages  | boolean   | If you have configured storages in your settings, you can skip them with this parameter.                                                       |
+| Parameter Name           | Data Type | Description                                                                                                                                                           |
+|--------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| date-interval            | string    | Defines which data should be deleted. We use the PHP DateInterval format. You can find more information [here](https://www.php.net/manual/en/class.dateinterval.php). |
+| skip-configured-storages | boolean   | If you have configured storages in your settings, you can skip them with this parameter.                                                                              |
+| remove-files             | boolean   | The PersistentResource that is potentially attached to the database storage entry will be removed as well.                                                            |
 
 
 
 ```
-./flow databasestorage:cleanupallstorages --date-interval=P1M
+./flow databasestorage:cleanupallstorages --date-interval=P1M --remove-files
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -114,11 +114,11 @@ Run the cleanup command for the configured storages:
 
 You can also run a cleanup command for all existing storages. The command comes with parameters:
 
-| Parameter Name           | Data Type | Description                                                                                                                                                           |
-|--------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| date-interval            | string    | Defines which data should be deleted. We use the PHP DateInterval format. You can find more information [here](https://www.php.net/manual/en/class.dateinterval.php). |
-| skip-configured-storages | boolean   | If you have configured storages in your settings, you can skip them with this parameter.                                                                              |
-| remove-files             | boolean   | The PersistentResource that is potentially attached to the database storage entry will be removed as well.                                                            |
+| Parameter Name              | Data Type | Description                                                                                                                                                           |
+|-----------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| date-interval               | string    | Defines which data should be deleted. We use the PHP DateInterval format. You can find more information [here](https://www.php.net/manual/en/class.dateinterval.php). |
+| include-configured-storages | boolean   | If you have configured storages in your settings, you can skip them with this parameter.                                                                              |
+| remove-files                | boolean   | The PersistentResource that is potentially attached to the database storage entry will be removed as well.                                                            |
 
 
 


### PR DESCRIPTION
Introduced two new cleanup commands to be able to manage database storage entries that are outdated:
  1. Configure settings for several storages and define custom intervals.
  2. Cleanup all storages using parameters like `date-interval`.


### Cleanup all storages


| Parameter Name              | Data Type | Description                                                                                                                                                           |
|-----------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| date-interval               | string    | Defines which data should be deleted. We use the PHP DateInterval format. You can find more information [here](https://www.php.net/manual/en/class.dateinterval.php). |
| include-configured-storages | boolean   | If you have configured storages in your settings, you can skip them with this parameter.                                                                              |
| remove-files                | boolean   | The PersistentResource that is potentially attached to the database storage entry will be removed as well.                                                            |


```
./flow databasestorage:cleanupallstorages --date-interval=P1M
```

This will remove all entries that are older than 1 month. Except entries from storages that have been configured with their own interval settings.

### Cleanup configured storages

```
./flow databasestorage:cleanupconfiguredstorages
```

These command will cleanup all storages that have been configured and nothing else.
You are able to define custom intervals per storage.

```yaml
Wegmeister:
  DatabaseStorage:
    cleanup:
      # Add storage identifier you wish to be cleaned up
      storageIdentifier1:
        dateInterval: "P6M"
      storageIdentifier2:
          dateInterval: "P1Y"
```

<img width="1120" alt="Screenshot 2024-11-24 at 20 40 03" src="https://github.com/user-attachments/assets/35937be7-98e5-4cb0-9b70-bfc705b171fc">


### Goal
These changes address the issue of database growth by providing flexible and precise cleanup tools.
- Focused cleanup logic on the age of entries to prevent old data from cluttering the module.
- Ensures the database remains efficient and manageable over time by removing outdated entries.

