### PR TITLE
chore: Update dependencies for phpspreadsheet and add suggestion for neos/fusion-form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "This package adds the ability to store inputs of a form (or other input) into database and export the stored data as xlsx.",
     "require": {
         "neos/form": "^5.0",
-        "phpoffice/phpspreadsheet": "^1.2"
+        "phpoffice/phpspreadsheet": "^1.2 || ^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
             "Wegmeister\\DatabaseStorage\\": "Classes/"
         }
     },
+    "suggest": {
+        "neos/fusion-form": "New Form rendering with Fusion and AFX"
+    },
     "extra": {
         "neos": {
             "package-key": "Wegmeister.DatabaseStorage"


### PR DESCRIPTION
This is only a small update to support new versions of `phpoffice/phpspreadsheet`, as no significant changes were made there, that lead to issues here. So we will move on with newer versions of it. 

Also this adds a suggestion to [Neos.Fusion.Form](https://github.com/neos/fusion-form).