### PR TITLE
Bugfix // Unify array output to support both associative and indexed structures

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -31,6 +31,7 @@ Wegmeister:
     subject: 'Database Export'
     datetimeFormat: 'Y-m-d H:i:s'
     itemsPerPage: 20
+    listPrefix: '-'
     nodeTypesIgnoredInFinisher:
       - 'Neos.Form.Builder:Section'
       - 'Neos.Form.Builder:StaticText'

--- a/Readme.md
+++ b/Readme.md
@@ -79,6 +79,8 @@ Wegmeister:
     datetimeFormat: 'Y-m-d H:i:s'
     # Number of entries per page on the identifier list view
     itemsPerPage: 20
+    # Array list item prefix on the identifier list view
+    listPrefix: '-'
     # Form element types that should not be stored by the finisher (for Node-based forms)
     nodeTypesIgnoredInFinisher:
       - 'Neos.Form.Builder:Section'


### PR DESCRIPTION
The array rendering logic has been improved to correctly display both associative
and indexed arrays without losing key information. Keys are now included when
present, ensuring meaningful output while maintaining the previous behavior for
flat lists.

This update prevents missing labels in nested or associative data structures and
keeps the formatting consistent for all array types.

Example before:
- 14
- 1
- 1

Example after:
- Google Chrome: 14
- Firefox: 1
- Safari: 1
