### PR TITLE
make compatible with Neos 9

### DIFF
--- a/Classes/Command/DatabaseStorageCommandController.php
+++ b/Classes/Command/DatabaseStorageCommandController.php
@@ -8,21 +8,13 @@ use Wegmeister\DatabaseStorage\Service\DatabaseStorageService;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 
-/**
- * @Flow\Scope("singleton")
- */
+#[Flow\Scope("singleton")]
 class DatabaseStorageCommandController extends CommandController
 {
-    /**
-     * @var DatabaseStorageService
-     * @Flow\Inject
-     */
+    #[Flow\Inject]
     protected DatabaseStorageService $databaseStorageService;
 
-    /**
-     * @Flow\InjectConfiguration(package="Wegmeister.DatabaseStorage", path="cleanup")
-     * @var array|null
-     */
+    #[Flow\InjectConfiguration(path: "cleanup", package: "Wegmeister.DatabaseStorage")]
     protected ?array $storageCleanupConfiguration;
 
     /**
@@ -47,12 +39,8 @@ class DatabaseStorageCommandController extends CommandController
     /**
      * Deletes entries of all storages older than given date interval.
      * You can also skip the configured storages.
-     *
-     * @param string $dateInterval
-     * @param bool $removeFiles
-     * @param bool $includeConfiguredStorages
      */
-    public function cleanupAllStoragesCommand(string $dateInterval, $removeFiles = false, bool $includeConfiguredStorages = false): void
+    public function cleanupAllStoragesCommand(string $dateInterval, bool $removeFiles = false, bool $includeConfiguredStorages = false): void
     {
         $this->outputFormatted('<b>Cleanup of all storages</b>');
         $this->outputLine('');
@@ -89,11 +77,6 @@ class DatabaseStorageCommandController extends CommandController
     /**
      * Get the cleanup results for the given storage identifiers.
      * If no date interval is provided, the cleanup configuration will be used.
-     *
-     * @param array $storageIdentifiers
-     * @param DateInterval|null $dateInterval
-     * @param int $daysToKeepData
-     * @return array
      */
     protected function getCleanupResultsForStorageIdentifier(array $storageIdentifiers, ?DateInterval $dateInterval = null, int $daysToKeepData = -1, $removeFiles = false): array
     {
@@ -139,9 +122,6 @@ class DatabaseStorageCommandController extends CommandController
 
     /**
      * Get the date interval from the configuration and ensure it is valid.
-     *
-     * @param string $storageIdentifier
-     * @return DateInterval
      */
     protected function getDateIntervalFromConfiguration(string $storageIdentifier): DateInterval
     {
@@ -168,9 +148,6 @@ class DatabaseStorageCommandController extends CommandController
 
     /**
      * Get the amount of days to keep from the configured date interval
-     *
-     * @param DateInterval $dateInterval
-     * @return int
      */
     protected function getDaysToKeepFromConfiguredInterval(DateInterval $dateInterval): int
     {

--- a/Classes/Controller/DatabaseStorageController.php
+++ b/Classes/Controller/DatabaseStorageController.php
@@ -29,9 +29,8 @@ use Wegmeister\DatabaseStorage\Service\DatabaseStorageService;
 
 /**
  * The Database Storage controller
- *
- * @Flow\Scope("singleton")
  */
+#[Flow\Scope("singleton")]
 class DatabaseStorageController extends ActionController
 {
     /**
@@ -62,52 +61,18 @@ class DatabaseStorageController extends ActionController
         ],
     ];
 
-    /**
-     * Instance of the database storage repository.
-     *
-     * @Flow\Inject
-     * @var DatabaseStorageRepository
-     */
-    protected $databaseStorageRepository;
+    #[Flow\Inject]
+    protected DatabaseStorageRepository $databaseStorageRepository;
 
-    /**
-     * @var DatabaseStorageService
-     */
-    protected $databaseStorageService;
+    #[Flow\Inject]
+    protected Translator $translator;
 
-    /**
-     * Instance of the translator interface.
-     *
-     * @Flow\Inject
-     * @var Translator
-     */
-    protected $translator;
-
-    /**
-     * Settings of this plugin.
-     *
-     * @var array
-     */
-    protected $settings;
-
-    /**
-     * Inject the settings
-     *
-     * @param array $settings The settings to inject.
-     *
-     * @return void
-     */
-    public function injectSettings(array $settings)
-    {
-        $this->settings = $settings;
-    }
+    protected DatabaseStorageService $databaseStorageService;
 
     /**
      * Show list of identifiers
-     *
-     * @return void
      */
-    public function indexAction()
+    public function indexAction(): void
     {
         $this->view->assign('identifiers', $this->databaseStorageRepository->findStorageidentifiers());
     }
@@ -117,10 +82,8 @@ class DatabaseStorageController extends ActionController
      *
      * @param string $identifier The storage identifier.
      * @param int $currentPage
-     * @return void
-     * @throws StopActionException
      */
-    public function showAction(string $identifier, int $currentPage = 1)
+    public function showAction(string $identifier, int $currentPage = 1): void
     {
         $itemsPerPage = (int)($this->settings['itemsPerPage'] ?? 10);
         $offset = ($currentPage - 1) * $itemsPerPage;
@@ -173,15 +136,9 @@ class DatabaseStorageController extends ActionController
 
     /**
      * Delete an entry from the list of identifiers.
-     *
-     * @param DatabaseStorage $entry The DatabaseStorage entry
-     *
-     * @return void
      */
-    public function deleteAction(
-        DatabaseStorage $entry,
-        bool $removeAttachedResources = false
-    ) {
+    public function deleteAction(DatabaseStorage $entry, bool $removeAttachedResources = false): void
+    {
         $identifier = $entry->getStorageidentifier();
         $this->databaseStorageRepository->remove($entry, $removeAttachedResources);
         $this->addFlashMessage(
@@ -202,11 +159,9 @@ class DatabaseStorageController extends ActionController
      *
      * @param string $identifier The storage identifier for the entries to be removed.
      * @param bool $redirect Redirect to index?
-     * @param bool $removeAttachedResource Remove attached resources?
-     *
-     * @return void
+     * @param bool $removeAttachedResources Remove attached resources?
      */
-    public function deleteAllAction(string $identifier, bool $redirect = false, bool $removeAttachedResources = false)
+    public function deleteAllAction(string $identifier, bool $redirect = false, bool $removeAttachedResources = false): void
     {
         $count = $this->databaseStorageRepository->deleteByStorageIdentifierAndDateInterval(
             $identifier,
@@ -239,10 +194,8 @@ class DatabaseStorageController extends ActionController
      * @param string $identifier The storage identifier that should be exported.
      * @param string $writerType The writer type/export format to be used.
      * @param bool $exportDateTime Should the datetime be exported?
-     *
-     * @return void
      */
-    public function exportAction(string $identifier, string $writerType = 'Xlsx', bool $exportDateTime = false)
+    public function exportAction(string $identifier, string $writerType = 'Xlsx', bool $exportDateTime = false): void
     {
         if (!isset(self::$types[$writerType])) {
             throw new WriterException('No writer available for type ' . $writerType . '.', 1521787983);

--- a/Classes/Domain/Model/DatabaseStorage.php
+++ b/Classes/Domain/Model/DatabaseStorage.php
@@ -17,9 +17,7 @@ namespace Wegmeister\DatabaseStorage\Domain\Model;
 use Neos\Flow\Annotations as Flow;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @Flow\Entity
- */
+#[Flow\Entity]
 class DatabaseStorage
 {
 
@@ -42,77 +40,38 @@ class DatabaseStorage
     protected $properties = [];
 
     /**
-     * DateTime the entry was created.
-     *
-     * @var \DateTime
      * @Flow\Validate(type="NotEmpty")
      */
-    protected $datetime;
+    protected \DateTime $datetime;
 
-    /**
-     * Get identifier
-     *
-     * @return string
-     */
-    public function getStorageidentifier()
+    public function getStorageidentifier(): string
     {
         return $this->storageidentifier;
     }
 
-    /**
-     * Set the identifier
-     *
-     * @param string $storageIdentifier The identifier for the entry.
-     *
-     * @return DatabaseStorage
-     */
-    public function setStorageidentifier(string $storageIdentifier)
+    public function setStorageidentifier(string $storageIdentifier): DatabaseStorage
     {
         $this->storageidentifier = $storageIdentifier;
         return $this;
     }
 
-    /**
-     * Get properties
-     *
-     * @return array
-     */
-    public function getProperties()
+    public function getProperties(): array
     {
         return $this->properties;
     }
 
-    /**
-     * Set properties
-     *
-     * @param array $properties Array of the properties.
-     *
-     * @return DatabaseStorage
-     */
-    public function setProperties(array $properties)
+    public function setProperties(array $properties): DatabaseStorage
     {
         $this->properties = $properties;
         return $this;
     }
 
-    /**
-     * Get datetime
-     *
-     * @return \DateTime
-     */
-    public function getDateTime()
+    public function getDateTime(): \DateTime
     {
         return $this->datetime;
     }
 
-    /**
-     * Set datetime
-     *
-     * @param \DateTime $datetime
-     *
-     * @return DatabaseStorage
-     */
-    public function setDateTime(\DateTime $datetime)
+    public function setDateTime(\DateTime $datetime): DatabaseStorage
     {
         $this->datetime = $datetime;
         return $this;

--- a/Classes/Domain/Model/DatabaseStorage.php
+++ b/Classes/Domain/Model/DatabaseStorage.php
@@ -62,13 +62,13 @@ class DatabaseStorage
     /**
      * Set the identifier
      *
-     * @param string $identifier The identifier for the entry.
+     * @param string $storageIdentifier The identifier for the entry.
      *
      * @return DatabaseStorage
      */
-    public function setStorageidentifier(string $identifier)
+    public function setStorageidentifier(string $storageIdentifier)
     {
-        $this->storageidentifier = $identifier;
+        $this->storageidentifier = $storageIdentifier;
         return $this;
     }
 

--- a/Classes/Domain/Repository/DatabaseStorageRepository.php
+++ b/Classes/Domain/Repository/DatabaseStorageRepository.php
@@ -29,18 +29,17 @@ use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Wegmeister\DatabaseStorage\Domain\Model\DatabaseStorage;
 
-/**
- * @Flow\Scope("singleton")
- */
+#[Flow\Scope("singleton")]
 class DatabaseStorageRepository extends Repository
 {
     /**
      * Doctrine's Entity Manager.
-     *
-     * @Flow\Inject
-     * @var EntityManagerInterface
      */
-    protected $entityManager;
+    #[Flow\Inject]
+    protected EntityManagerInterface $entityManager;
+
+    #[Flow\Inject]
+    protected ResourceManager $resourceManager;
 
     /**
      * Update default orderings.
@@ -52,26 +51,12 @@ class DatabaseStorageRepository extends Repository
         'datetime' => QueryInterface::ORDER_DESCENDING
     ];
 
-    /**
-     * List of identifiers.
-     *
-     * @var ?array
-     */
-    protected $identifiers = null;
-
-    /**
-     * @Flow\Inject
-     * @var ResourceManager
-     */
-    protected $resourceManager;
-
+    protected ?array $identifiers = null;
 
     /**
      * Find all identifiers.
-     *
-     * @return mixed
      */
-    public function findStorageidentifiers()
+    public function findStorageidentifiers(): ?array
     {
         if ($this->identifiers === null) {
             $this->identifiers = $this->getStorageIdentifiers();
@@ -83,12 +68,8 @@ class DatabaseStorageRepository extends Repository
     /**
      * Delete all entries of a storage by its identifier and an optional date interval.
      *
-     * @param string $storageIdentifier Storage identifier
-     * @param \DateInterval|null $dateInterval Date interval
-     * @param bool $removeAttachedResource
-     * @return int
      * @throws IllegalObjectTypeException
-     * @throws InvalidQueryException
+     * @throws InvalidQueryException|\DateInvalidOperationException
      */
     public function deleteByStorageIdentifierAndDateInterval(
         string $storageIdentifier,
@@ -126,14 +107,14 @@ class DatabaseStorageRepository extends Repository
      *
      * @param object $object The object to remove
      * @param bool $removeAttachedResources Also remove all attached resources?
-     * @return void
+     *
      * @throws IllegalObjectTypeException
      * @api
      */
-    public function remove($entry, bool $removeAttachedResources = false): void
+    public function remove($object, bool $removeAttachedResources = false): void
     {
         if ($removeAttachedResources) {
-            foreach ($entry->getProperties() as $property) {
+            foreach ($object->getProperties() as $property) {
                 if (!$property instanceof PersistentResource) {
                     continue;
                 }
@@ -149,15 +130,12 @@ class DatabaseStorageRepository extends Repository
             }
         }
 
-        parent::remove($entry);
+        parent::remove($object);
     }
 
     /**
      * Get the list of all storage identifiers. Optionally exclude some.
      * For performance reasons, this method does not use the ORM.
-     *
-     * @param array $excludedIdentifiers
-     * @return array
      */
     public function getStorageIdentifiers(array $excludedIdentifiers = []): array
     {
@@ -178,9 +156,6 @@ class DatabaseStorageRepository extends Repository
 
     /**
      * Checks if there are entries for given storage identifier.
-     *
-     * @param string $storageIdentifier
-     * @return int
      */
     public function getAmountOfEntriesByStorageIdentifier(string $storageIdentifier): int
     {
@@ -202,7 +177,6 @@ class DatabaseStorageRepository extends Repository
      * @param string $storageIdentifier
      * @param int $limit
      * @param int $offset
-     * @return QueryResultInterface
      */
     public function findPaginatedByStorageidentifier(string $storageIdentifier, int $limit, int $offset): QueryResultInterface
     {

--- a/Classes/Finishers/DatabaseStorageFinisher.php
+++ b/Classes/Finishers/DatabaseStorageFinisher.php
@@ -19,7 +19,6 @@ namespace Wegmeister\DatabaseStorage\Finishers;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Form\Core\Model\AbstractFinisher;
-use Neos\Form\Exception\FinisherException;
 use Neos\Media\Domain\Model\ResourceBasedInterface;
 
 use Wegmeister\DatabaseStorage\Domain\Model\DatabaseStorage;
@@ -31,34 +30,21 @@ use Wegmeister\DatabaseStorage\Service\DatabaseStorageService;
  */
 class DatabaseStorageFinisher extends AbstractFinisher
 {
-    /**
-     * Instance of the database storage repository.
-     *
-     * @Flow\Inject
-     * @var DatabaseStorageRepository
-     */
-    protected $databaseStorageRepository;
+    #[Flow\Inject]
+    protected DatabaseStorageRepository $databaseStorageRepository;
 
-    /**
-     * @var DatabaseStorageService
-     */
-    protected $databaseStorageService;
+    #[Flow\Inject]
+    protected PersistenceManagerInterface $persistenceManager;
 
-    /**
-     * @Flow\Inject
-     * @var PersistenceManagerInterface
-     */
-    protected $persistenceManager;
+    protected DatabaseStorageService $databaseStorageService;
 
     /**
      * Executes this finisher
      *
      * @see AbstractFinisher::execute()
-     *
-     * @return void
-     * @throws FinisherException
+     * @throws \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
      */
-    protected function executeInternal()
+    protected function executeInternal(): void
     {
         $formRuntime = $this->finisherContext->getFormRuntime();
         $formValues = $formRuntime->getFormState()->getFormValues();

--- a/Classes/Finishers/DatabaseStorageFinisher.php
+++ b/Classes/Finishers/DatabaseStorageFinisher.php
@@ -63,25 +63,25 @@ class DatabaseStorageFinisher extends AbstractFinisher
         $formRuntime = $this->finisherContext->getFormRuntime();
         $formValues = $formRuntime->getFormState()->getFormValues();
 
-        $identifier = $this->parseOption('identifier');
-        if ($identifier) {
-            $this->databaseStorageService = new DatabaseStorageService($identifier);
+        $storageIdentifier = $this->parseOption('storageIdentifier');
+        if ($storageIdentifier) {
+            $this->databaseStorageService = new DatabaseStorageService($storageIdentifier);
         } else {
-            $identifier = '__undefined__';
+            $storageIdentifier = '__undefined__';
         }
 
         foreach ($formValues as $formElementIdentifier => $formValue) {
             if ($formValue instanceof ResourceBasedInterface) {
                 $formValues[$formElementIdentifier] = $formValue->getResource();
             }
-            if ($identifier && $this->databaseStorageService->formElementIdentifierMustBeIgnoredInFinisher($formElementIdentifier)) {
+            if ($storageIdentifier && $this->databaseStorageService->formElementIdentifierMustBeIgnoredInFinisher($formElementIdentifier)) {
                 unset($formValues[$formElementIdentifier]);
             }
         }
 
         $dbStorage = new DatabaseStorage();
         $dbStorage
-            ->setStorageidentifier($identifier)
+            ->setStorageidentifier($storageIdentifier)
             ->setProperties($formValues)
             ->setDateTime(new \DateTime());
 

--- a/Classes/Finishers/DatabaseStorageFinisher.php
+++ b/Classes/Finishers/DatabaseStorageFinisher.php
@@ -36,6 +36,7 @@ class DatabaseStorageFinisher extends AbstractFinisher
     #[Flow\Inject]
     protected PersistenceManagerInterface $persistenceManager;
 
+    #[Flow\Inject]
     protected DatabaseStorageService $databaseStorageService;
 
     /**

--- a/Classes/FusionForm/Runtime/Action/DatabaseStorageAction.php
+++ b/Classes/FusionForm/Runtime/Action/DatabaseStorageAction.php
@@ -21,16 +21,12 @@ use Wegmeister\DatabaseStorage\Domain\Repository\DatabaseStorageRepository;
 
 class DatabaseStorageAction extends AbstractAction
 {
-
-    /**
-     * @Flow\Inject
-     * @var DatabaseStorageRepository
-     */
-    protected $databaseStorageRepository;
+    #[Flow\Inject]
+    protected DatabaseStorageRepository $databaseStorageRepository;
 
     /**
      * @return ActionResponse|null
-     * @throws ActionException
+     * @throws \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
      */
     public function perform(): ?ActionResponse
     {

--- a/Classes/FusionForm/Runtime/Action/DatabaseStorageAction.php
+++ b/Classes/FusionForm/Runtime/Action/DatabaseStorageAction.php
@@ -34,11 +34,11 @@ class DatabaseStorageAction extends AbstractAction
      */
     public function perform(): ?ActionResponse
     {
-        $identifier = $this->options['identifier'];
+        $storageIdentifier = $this->options['storageIdentifier'];
         $formValues = $this->options['formValues'];
 
-        if (!$identifier) {
-            $identifier = '__undefined__';
+        if (!$storageIdentifier) {
+            $storageIdentifier = '__undefined__';
         }
 
         foreach ($formValues as $formElementIdentifier => $formValue) {
@@ -49,7 +49,7 @@ class DatabaseStorageAction extends AbstractAction
 
         $dbStorage = new DatabaseStorage();
         $dbStorage
-            ->setStorageidentifier($identifier)
+            ->setStorageidentifier($storageIdentifier)
             ->setProperties($formValues)
             ->setDateTime(new \DateTime());
 

--- a/Classes/Service/DatabaseStorageService.php
+++ b/Classes/Service/DatabaseStorageService.php
@@ -35,64 +35,35 @@ use Neos\Flow\ResourceManagement\ResourceManager;
 use Wegmeister\DatabaseStorage\Domain\Model\DatabaseStorage;
 use Wegmeister\DatabaseStorage\Domain\Repository\DatabaseStorageRepository;
 
-/**
- * @Flow\Scope("singleton")
- */
+#[Flow\Scope("singleton")]
 class DatabaseStorageService
 {
-    /**
-     * @var DatabaseStorageRepository
-     * @Flow\Inject
-     */
-    protected $databaseStorageRepository;
-
-    /**
-     * @var array
-     */
-    protected $formElementsNodeData;
-
-    /**
-     * @var string
-     */
-    protected $formStorageIdentifier;
-
-    /**
-     * @var array
-     * @Flow\InjectConfiguration(path="nodeTypesIgnoredInFinisher", package="Wegmeister.DatabaseStorage")
-     */
-    protected $nodeTypesIgnoredInFinisher;
-
-    /**
-     * @var string
-     * @Flow\InjectConfiguration(path="listPrefix", package="Wegmeister.DatabaseStorage")
-     */
-    protected $listPrefix;
-
-    /**
-     * @var array
-     * @Flow\InjectConfiguration(path="nodeTypesIgnoredInExport", package="Wegmeister.DatabaseStorage")
-     */
-    protected $nodeTypesIgnoredInExport;
-
-    /**
-     * @var string
-     * @Flow\InjectConfiguration(path="datetimeFormat", package="Wegmeister.DatabaseStorage")
-     */
-    protected $datetimeFormat;
-
-    /**
-     * @var array
-     */
-    protected $preparedDimensions;
-
     #[Flow\Inject]
     protected ContentRepositoryRegistry $contentRepositoryRegistry;
 
-    /**
-     * @Flow\Inject
-     * @var ResourceManager
-     */
-    protected $resourceManager;
+    #[Flow\Inject]
+    protected ResourceManager $resourceManager;
+
+    #[Flow\Inject]
+    protected DatabaseStorageRepository $databaseStorageRepository;
+
+    #[Flow\InjectConfiguration(path: "nodeTypesIgnoredInFinisher", package: "Wegmeister.DatabaseStorage")]
+    protected array $nodeTypesIgnoredInFinisher;
+
+    #[Flow\InjectConfiguration(path: "listPrefix", package: "Wegmeister.DatabaseStorage")]
+    protected string $listPrefix;
+
+    #[Flow\InjectConfiguration(path: "nodeTypesIgnoredInExport", package: "Wegmeister.DatabaseStorage")]
+    protected array $nodeTypesIgnoredInExport;
+
+    #[Flow\InjectConfiguration(path: "datetimeFormat", package: "Wegmeister.DatabaseStorage")]
+    protected string $datetimeFormat;
+
+    protected array $formElementsNodeData = [];
+
+    protected string $formStorageIdentifier;
+
+    protected ?array $preparedDimensions = null;
 
     public function __construct(string $formStorageIdentifier = '')
     {
@@ -120,9 +91,6 @@ class DatabaseStorageService
      * - The Node identifier
      * - The speaking identifier of the FormElement
      * - The label of the FormElement
-     *
-     * @param string $identifier
-     * @return array|null
      */
     public function getFormElementDataByIdentifier(string $identifier): ?array
     {
@@ -179,8 +147,6 @@ class DatabaseStorageService
      *
      * @param array $inputArray The multidimensional array of the dimensions
      * @param array $keys The keys of the dimensions
-     *
-     * @return array
      */
     protected function createDimensionCombinations(array $inputArray, array $combinations = []): array
     {
@@ -213,7 +179,6 @@ class DatabaseStorageService
      * If the Node-based form is still available, node data such as the "speaking" identifier, the label
      * are looked up to provide the best possible label and value matching for the export.
      *
-     * @return array|null
      * @throws \Neos\Eel\Exception
      * @throws AccessDenied
      */
@@ -316,9 +281,6 @@ class DatabaseStorageService
 
     /**
      * Get field labels of all entries to allow exporting all fields added/removed/changed over time
-     *
-     * @param QueryResultInterface $entries
-     * @return array
      */
     public function getFormElementLabels(QueryResultInterface $entries): array
     {
@@ -356,10 +318,6 @@ class DatabaseStorageService
     /**
      * We check the given entry if there is a value for the given display label
      * The check is performed against the key, the nodeIdentifier and the speakingIdentifier
-     *
-     * @param DatabaseStorage $entry
-     * @param string $formElementLabel
-     * @return string
      */
     public function getValueFromEntryProperty(DatabaseStorage $entry, string $formElementLabel): string
     {
@@ -395,8 +353,6 @@ class DatabaseStorageService
      *
      * @param mixed $value The database column value.
      * @param int $indent The level of indentation (for array values).
-     *
-     * @return string
      */
     protected function getStringValue($value, int $indent = 0): string
     {
@@ -452,9 +408,6 @@ class DatabaseStorageService
 
     /**
      * Checks if there are entries for given storage identifier.
-     *
-     * @param string $storageIdentifier
-     * @return int
      */
     public function getAmountOfEntriesByStorageIdentifier(string $storageIdentifier): int
     {
@@ -463,11 +416,6 @@ class DatabaseStorageService
 
     /**
      * Deletes entries of a storage by its identifier and an optional date interval.
-     *
-     * @param string $storageIdentifier Storage identifier
-     * @param \DateInterval $dateInterval Date interval
-     * @param bool $removeFiles
-     * @return int
      */
     public function cleanupByStorageIdentifierAndDateInterval(string $storageIdentifier, \DateInterval $dateInterval, bool $removeFiles = false): int
     {
@@ -479,10 +427,7 @@ class DatabaseStorageService
     }
 
     /**
-     * Get a list of all storage identifiers.
-     *
-     * @param array $excludedStorageIdentifiers
-     * @return array
+     * Get a list of all storage identifiers
      */
     public function getListOfStorageIdentifiers(array $excludedStorageIdentifiers = []): array
     {

--- a/Classes/Service/DatabaseStorageService.php
+++ b/Classes/Service/DatabaseStorageService.php
@@ -20,6 +20,7 @@ use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindClosestNodeFi
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\PropertyValue\Criteria\PropertyValueEquals;
+use Neos\ContentRepository\Core\Projection\ContentGraph\VisibilityConstraints;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Node\PropertyName;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -247,7 +248,7 @@ class DatabaseStorageService
         $contentGraph =  $contentRepository->getContentGraph(WorkspaceName::forLive());
         $sitesRootNodeNode = $contentGraph->findRootNodeAggregateByType(NodeTypeName::fromString('Neos.Neos:Sites'));
         $contentSubgraph = $contentGraph->getSubgraph(
-            DimensionSpacePoint::createWithoutDimensions(), NeosVisibilityConstraints::excludeRemoved()
+            DimensionSpacePoint::createWithoutDimensions(), VisibilityConstraints::createEmpty()
         );
         $finisherNodes = $contentSubgraph->findDescendantNodes(
             $sitesRootNodeNode->nodeAggregateId,
@@ -270,7 +271,7 @@ class DatabaseStorageService
 
         // Find the NodeBasedForm owning the Finisher
         $formNode = $contentSubgraph->findClosestNode(
-            $sitesRootNodeNode->nodeAggregateId,
+            $finisherNodes->first()->aggregateId,
             FindClosestNodeFilter::create(NodeTypeCriteria::fromFilterString('Neos.Form.Builder:NodeBasedForm'))
         );
 

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -7,20 +7,26 @@
 'Neos.Form.Builder:IdentifierMixin':
   abstract: true
 
-
 'Wegmeister.DatabaseStorage:DatabaseStorageFinisher':
   superTypes:
     'Neos.Form.Builder:AbstractFinisher': true
     'Neos.Form.Builder:IdentifierMixin': true
   ui:
     label: 'Database Storage Finisher'
-    icon: 'icon-database'
-    group: 'form.finisher'
+    icon: icon-database
+    group: form.finisher
   properties:
-    'identifier':
+    'storageIdentifier':
+      type: string
       ui:
+        label: 'Wegmeister.DatabaseStorage:Main:storage.storageIdentifier'
+        reloadIfChanged: true
         showInCreationDialog: true
         inspector:
-          group: 'finisher'
+          group: finisher
       validation:
-        'Neos.Neos/Validation/NotEmptyValidator': {  }
+        Neos.Neos/Validation/NotEmptyValidator: {  }
+        'Neos.Neos/Validation/StringLengthValidator':
+          maximum: 255
+        'Neos.Neos/Validation/RegularExpressionValidator':
+          regularExpression: '/^[a-z0-9\-]+$/i'

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -1,62 +1,65 @@
 privilegeTargets:
-  'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
+  Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege:
     'Wegmeister.DatabaseStorage:Backend.ListDatabaseStorageItems':
-      matcher: 'method(Wegmeister\DatabaseStorage\Controller\DatabaseStorageController->indexAction())'
+      matcher: method(Wegmeister\DatabaseStorage\Controller\DatabaseStorageController->indexAction())
     'Wegmeister.DatabaseStorage:Backend.DatabaseStorageViewer':
-      matcher: 'method(Wegmeister\DatabaseStorage\Controller\DatabaseStorageController->(index|show)Action())'
+      matcher: method(Wegmeister\DatabaseStorage\Controller\DatabaseStorageController->(index|show)Action())
     'Wegmeister.DatabaseStorage:Backend.DatabaseStorageExporter':
-      matcher: 'method(Wegmeister\DatabaseStorage\Controller\DatabaseStorageController->(export)Action())'
+      matcher: method(Wegmeister\DatabaseStorage\Controller\DatabaseStorageController->(export)Action())
     'Wegmeister.DatabaseStorage:Backend.DatabaseStorageDeleter':
-      matcher: 'method(Wegmeister\DatabaseStorage\Controller\DatabaseStorageController->(delete|deleteAll)Action())'
-
+      matcher: method(Wegmeister\DatabaseStorage\Controller\DatabaseStorageController->(delete|deleteAll)Action())
 roles:
   'Wegmeister.DatabaseStorage:DatabaseStorageViewer':
-    label: Database Storage Viewer
-    description: User is allowed to view all database storage lists and their entries.
+    label: 'Database Storage Viewer'
+    description: 'User is allowed to view all database storage lists and their entries.'
     privileges:
-      - privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.ListDatabaseStorageItems'
+      -
+        privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.ListDatabaseStorageItems'
         permission: GRANT
-      - privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageViewer'
+      -
+        privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageViewer'
         permission: GRANT
-
   'Wegmeister.DatabaseStorage:DatabaseStorageExporter':
-    label: Database Storage Exporter
-    description: |
-      User is allowed to export all database storage lists.
-      Requires a role that can view the lists, otherwise only direct links to the export will work.
+    label: 'Database Storage Exporter'
+    description: "User is allowed to export all database storage lists.\nRequires a role that can view the lists, otherwise only direct links to the export will work.\n"
     privileges:
-      - privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageExporter'
+      -
+        privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageExporter'
         permission: GRANT
-
   'Wegmeister.DatabaseStorage:DatabaseStorageDeleter':
-    label: Database Storage Deleter
-    description: |
-      User is allowed to delete all database storage lists or single entries.
-      Requires a role that can view the lists, otherwise only direct links to delete a list or an entry will work.
+    label: 'Database Storage Deleter'
+    description: "User is allowed to delete all database storage lists or single entries.\nRequires a role that can view the lists, otherwise only direct links to delete a list or an entry will work.\n"
     privileges:
-      - privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageDeleter'
+      -
+        privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageDeleter'
         permission: GRANT
-
   'Wegmeister.DatabaseStorage:DatabaseStorageAdmin':
-    label: Database Storage Admin
-    description: User is allowed to view, export and delete all database storage lists and their entries.
+    label: 'Database Storage Admin'
+    description: 'User is allowed to view, export and delete all database storage lists and their entries.'
     privileges:
-      - privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.ListDatabaseStorageItems'
+      -
+        privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.ListDatabaseStorageItems'
         permission: GRANT
-      - privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageViewer'
+      -
+        privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageViewer'
         permission: GRANT
-      - privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageExporter'
+      -
+        privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageExporter'
         permission: GRANT
-      - privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageDeleter'
+      -
+        privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageDeleter'
         permission: GRANT
-
   'Neos.Neos:Administrator':
     privileges:
-      - privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.ListDatabaseStorageItems'
+      -
+        privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.ListDatabaseStorageItems'
         permission: GRANT
-      - privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageViewer'
+      -
+        privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageViewer'
         permission: GRANT
-      - privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageExporter'
+      -
+        privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageExporter'
         permission: GRANT
-      - privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageDeleter'
+      -
+        privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.DatabaseStorageDeleter'
         permission: GRANT

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -9,7 +9,7 @@ Neos:
   Neos:
     fusion:
       autoInclude:
-        'Wegmeister.DatabaseStorage': true
+        Wegmeister.DatabaseStorage: true
     modules:
       databaseStorage:
         label: 'Wegmeister.DatabaseStorage:Main:storage.databaseStorage'
@@ -17,13 +17,11 @@ Neos:
         description: 'Wegmeister.DatabaseStorage:Main:storage.databaseStorageDescription'
         icon: icon-database
         privilegeTarget: 'Wegmeister.DatabaseStorage:Backend.ListDatabaseStorageItems'
-
     userInterface:
       translation:
         autoInclude:
-          'Wegmeister.DatabaseStorage':
-            - 'Main'
-
+          Wegmeister.DatabaseStorage:
+            - Main
 Wegmeister:
   DatabaseStorage:
     creator: 'die wegmeister gmbh'

--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ finishers:
     options:
       # The identifier is used to group your data in the database.
       # You should avoid using the same identifier twice or your data could become a little messed up.
-      identifier: 'my-form-data'
+      storageIdentifier: 'my-form-data'
 ```
 
 ### Add DatabaseStorage using the Neos Form Builder
@@ -45,7 +45,7 @@ finishers:
 You can also use the DatabaseStorage with the [Neos.Form.Builder](https://github.com/neos/form-builder).
 You should be able to simply add DatabaseStorage as a finisher to your form.
 
-Don't forget to set a (unique) `identifier`!
+Don't forget to set a (unique) `storageIdentifier`!
 
 ### Add DatabaseStorage using a Fusion Form
 
@@ -56,7 +56,7 @@ Add the following configuration to your form action definition:
     databaseStorage {
         type = '\\Wegmeister\\DatabaseStorage\\FusionForm\\Runtime\\Action\\DatabaseStorageAction'
         options {
-            identifier = 'identifier-in-backend'
+            storageIdentifier = 'identifier-in-backend'
             formValues = ${data}
         }
     }

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -35,7 +35,7 @@
 			</trans-unit>
 
 			<!-- Index -->
-			<trans-unit id="storage.identifier" xml:space="preserve">
+			<trans-unit id="storage.storageIdentifier" xml:space="preserve">
 				<source>Identifier</source>
 				<target>ID</target>
 			</trans-unit>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -28,7 +28,7 @@
 			</trans-unit>
 
 			<!-- Index page -->
-			<trans-unit id="storage.identifier" xml:space="preserve">
+			<trans-unit id="storage.storageIdentifier" xml:space="preserve">
 				<source>Identifier</source>
 			</trans-unit>
 			<trans-unit id="storage.export" xml:space="preserve">

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": ["GPL-3.0-or-later"],
     "description": "This package adds the ability to store inputs of a form (or other input) into database and export the stored data as xlsx.",
     "require": {
+        "neos/neos": "^9.0",
         "neos/form": "^5.0 | ^6.0",
         "phpoffice/phpspreadsheet": "^1.2 || ^2.0 || ^3.0"
     },


### PR DESCRIPTION
Disclaimer: I only use (and tested) it using the Neos Form Builder

I renamed the property to storageIdentifier, because using identifier as property name led to
```
Warning: Attempt to read property "aggregateId" on null in /var/www/html/Packages/Application/Neos.Form.Builder/Classes/CommandHook/UniqueIdentifierCommandHook.php line 100£
```
because but this this value was already set on creation before the node was persisted. Therefore when the UniqueIdentifierHook tried to get the form, it could not even find the finisherNode in the DB. 

The other changes are adaptations to the new content repository and rector reformatings in the yaml files